### PR TITLE
feat: add between filter functionality and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ class ExpenseController extends Controller
 - **Example:**
     - `Filter::json('attributes', 'user.name', 'LIKE', 'user_name')` filters records where the `user.name` attribute in the `attributes` JSON column matches the `user_name` request parameter using a `LIKE` comparison.
     - `Filter::json('attributes', 'user.age', '>', 'user_age')` filters records where the `user.age` attribute in the `attributes` JSON column is greater than the `user_age` request parameter.
+### `Filter::between($attribute, $filterBy = null)`
+
+- **Description:** Filters records where the column value is within a specified range (inclusive).
+- **Parameters:**
+    - `$attribute`: The database column to apply the filter on.
+    - `$filterBy`: (Optional) The request parameter name to map to this filter. Defaults to the attribute name.
+- **Example Usage:**
+  - `Filter::between('expense_date', 'date_range')` filters records where the `expense_date` column falls between two values provided in the `date_range` parameter in the request.
+
+**API Request Example:**
+```bash
+  GET /api/expenses?filter[date_range]=2023-01-01,2023-12-31
+```
 
 ## Custom Filter Mapping
 You can map request parameters to different column names in your database. For example:
@@ -128,20 +141,31 @@ Now, if the request contains `filter[search]=Pizza`, the query will filter the `
 ## Example Usage in API Controller
 
 ```php
-public function index(): ExpenseCollection
-{
-    $expenses = Expense::query()
-        ->with(['category', 'period'])
-        ->filtrable([
-            Filter::like('description', 'search'),
-            Filter::exact('expense_date', 'date'),
-            Filter::json('attributes', 'user.name', 'LIKE', 'user_name'),
-            Filter::json('attributes', 'user.age', '>', 'user_age'),
-        ])
-        ->customPaginate();
-
-    return new ExpenseCollection($expenses);
-}
+      namespace App\Http\Controllers\Api\Finance;
+      
+      use App\Http\Controllers\Controller;
+      use App\Http\Resources\ExpenseCollection;
+      use App\Models\Expense;
+      use DevactionLabs\FilterablePackage\Filter;
+      
+      class ExpenseController extends Controller
+      {
+          public function index(): ExpenseCollection
+          {
+              $expenses = Expense::query()
+                  ->with(['category', 'period'])
+                  ->filtrable([
+                      Filter::like('description', 'search'),
+                      Filter::exact('expense_date', 'date'),
+                      Filter::between('expense_date', 'date_range'),
+                      Filter::json('attributes', 'user.name', 'LIKE', 'user_name'),
+                      Filter::json('attributes', 'user.age', '>', 'user_age'),
+                  ])
+                  ->customPaginate();
+      
+              return new ExpenseCollection($expenses);
+          }
+      }
 ```
 
 ## Pagination and Sorting

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -131,6 +131,11 @@ class Filter
         return new self($attribute, '<', $filterBy);
     }
 
+    public static function between(string $attribute, ?string $filterBy = null): self
+    {
+        return new self($attribute, 'BETWEEN', $filterBy);
+    }
+
     public static function relationship(string $relationship, string $attribute, string $operator = '=', ?string $filterBy = null): self
     {
         $filter = new self("{$relationship}.{$attribute}", $operator, $filterBy);
@@ -212,6 +217,18 @@ class Filter
      */
     public function setValue(string|int|array|Carbon|null $value): self
     {
+        if ($this->operator === 'BETWEEN') {
+            if (!is_array($value) || count($value) !== 2) {
+                throw new InvalidArgumentException('The value for BETWEEN must be an array with exactly two elements.');
+            }
+
+            foreach ($value as $item) {
+                if (!is_string($item) && !is_int($item)) {
+                    throw new InvalidArgumentException('The elements in the BETWEEN value array must be of type string or int.');
+                }
+            }
+        }
+
         if (is_array($value)) {
             foreach ($value as $item) {
                 if (!is_string($item)) {

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -81,7 +81,15 @@ trait Filterable
                 $attribute = $filter->getAttribute();
             }
 
-            // Handle JSON paths
+            if ($filter->getOperator() === 'BETWEEN') {
+                if (is_array($value) && count($value) === 2) {
+                    $builder->whereBetween($attribute, $value);
+                } else {
+                    throw new InvalidArgumentException('The value for BETWEEN must be an array with exactly two elements.');
+                }
+            }
+
+
             if ($filter->getJsonPath()) {
                 $attribute = DB::raw($attribute);
             }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -87,3 +87,19 @@ it('can create a json filter com in match', function () {
         ->and($filter->getOperator())->toBe('IN')
         ->and($filter->getValue())->toBe(['admin', 'user']);
 });
+
+
+it('can create a between filter', function () {
+    global $filters;
+    $filters = ['created_at' => ['2023-01-01', '2023-12-31']];
+
+    $filter = Filter::between('created_at');
+    expect($filter->getAttribute())->toBe('created_at')
+        ->and($filter->getOperator())->toBe('BETWEEN')
+        ->and($filter->getValue())->toBe(['2023-01-01', '2023-12-31']);
+});
+
+it('throws exception for invalid between filter value', function () {
+    $filter = Filter::between('created_at');
+    $filter->setValue(['2023-01-01']);
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
**Title:**
Add support for `BETWEEN` filter in the Filterable Package

**Description:**
This MR introduces support for the `BETWEEN` filter in the Filterable Package, enabling filtering of records based on value ranges (inclusive). The following changes have been made:

- Added the `Filter::between` method to simplify using the `BETWEEN` operator in queries.
- Updated the `setValue` method in the `Filter` class to validate arrays of values when using the `BETWEEN` operator.
- Added support for the `BETWEEN` operator in the `scopeFilterable` method.
- Updated the README with detailed documentation and examples of how to use the `BETWEEN` filter.
- Added unit tests to validate the functionality of the `BETWEEN` filter, covering both valid and invalid cases.

**Impact:**
- Enables applying range filters (`BETWEEN`) directly from API requests.
- Improves the package's flexibility for APIs that need to handle queries based on value ranges, such as date ranges or numerical intervals.