### PR TITLE
### Fix: Handle `BETWEEN` Filter for String Input in Filterable Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ class ExpenseController extends Controller
   - `Filter::between('expense_date', 'date_range')` filters records where the `expense_date` column falls between two values provided in the `date_range` parameter in the request.
 
 **API Request Example:**
-`` /api/expenses?filter[date_range]=2023-01-01,2023-12-31
+`` Get /api/expenses?filter[date_range]=2023-01-01,2023-12-31
 ```
 
 ## Custom Filter Mapping

--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ class ExpenseController extends Controller
   - `Filter::between('expense_date', 'date_range')` filters records where the `expense_date` column falls between two values provided in the `date_range` parameter in the request.
 
 **API Request Example:**
-```bash
-  GET /api/expenses?filter[date_range]=2023-01-01,2023-12-31
+`` /api/expenses?filter[date_range]=2023-01-01,2023-12-31
 ```
 
 ## Custom Filter Mapping

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "alex@devaction.com.br"
         }
     ],
-    "version": "v1.0.11",
+    "version": "v1.0.12",
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "illuminate/database": "^11.21",

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -46,6 +46,10 @@ class Filter
         if (isset($filters[$this->filterBy]) && $this->isValid($filters[$this->filterBy])) {
             $value = $filters[$this->filterBy];
 
+            if ($this->operator === 'BETWEEN' && is_string($value)) {
+                $value = explode(',', $value); // Converte a string em array
+            }
+
             if ($this->jsonPath) {
                 $decoded = null;
                 if (is_string($value)) {


### PR DESCRIPTION
### Fix: Handle `BETWEEN` Filter for String Input in Filterable Package

**Description:**
This PR fixes an issue where the `BETWEEN` filter was throwing an exception when the `filter` parameter was passed as a comma-separated string (e.g., `filter[created_at]=2025-01-19,2025-01-19`). The package now correctly parses the string into an array before applying the filter.

**Changes:**
- Updated the `setValueFromRequest` method in the `Filter` class to handle `BETWEEN` filters when the value is provided as a comma-separated string.
- Added logic to convert the string into an array using `explode(',')` if the operator is `BETWEEN`.
- Improved debugging messages for validation in the `scopeFilterable` method to ensure proper handling of the filter.

**Impact:**
- Fixes the issue where `BETWEEN` filters could not process string inputs.
- Ensures compatibility with requests where range filters are passed as comma-separated strings.

**Tested Scenarios:**
- Passing `filter[created_at]=2025-01-19,2025-01-19` now works as expected, filtering the records between the given dates.
- Validates cases where the `BETWEEN` filter value is not an array and throws the appropriate exception.

**Example API Request:**
```bash
GET /orders?filter[created_at]=2025-01-19,2025-01-19
