### PR TITLE
Fix per_page parameter issue with Laravel Octane

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "alex@devaction.com.br"
         }
     ],
-    "version": "v1.0.13",
+    "version": "v1.0.14",
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "illuminate/database": "^11.21",

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -25,7 +25,7 @@ trait Filterable
      */
     public function scopeCustomPaginate(Builder $builder, bool $useSimplePaginate = false, ?array $data = null): Paginator|LengthAwarePaginator
     {
-        $data = $data ?? Request::capture()->only('per_page', 'sort');
+        $data = $data ?? request()->only('per_page', 'sort');
 
         $order   = 'ASC';
         $perPage = $data['per_page'] ?? 15;


### PR DESCRIPTION
🖊️ MR Description

Problem:
The per_page parameter was not being applied correctly when running Laravel Octane with Swoole in the production environment. The default pagination value of 15 was always being used, regardless of the provided query parameter.

Cause:
The issue was caused by the use of Request::capture(), which is resolved once and cached in memory by Octane, leading to persistent state across requests.

Solution:
Replaced Request::capture() with request(), ensuring that the per_page parameter is correctly evaluated for each request.

Additional Actions:

    Restarted Laravel Octane after the change to clear cached request state.
    Validated pagination behavior locally and in production to confirm the fix.