### PR TITLE
fix: correct action SHAs and remove version from composer.json

### DIFF
--- a/.github/workflows/tags-and-quality.yml
+++ b/.github/workflows/tags-and-quality.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@6cbd405c7a6625e96a96b4a1d1e1a6c3e9d8ef67 # v2.3.3
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           name: Release v${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
- Updated softprops/action-gh-release to v2.0.9 with correct SHA
- Removed version field from composer.json (not needed for Packagist)
- Updated composer.lock accordingly

Fixes composer validate --strict warning and workflow errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)