### PR TITLE
chore: remove unnecessary test comments and add v2.1.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `filterable-package` will be documented in this file.
 
+## 2.1.0 - 2026-04-10
+
+### Added
+- **Laravel 13 support**: `illuminate/*` constraints expanded to `^11|^12|^13`
+
+### Security
+- **JSON path injection fix**: `setJsonPath()` now validates the path with a strict regex — only alphanumeric characters, dots, underscores, and brackets are accepted. Invalid paths throw `InvalidArgumentException`.
+- **Full-text column injection fix**: Column names passed to `Filter::fullText()` are validated before interpolation into PostgreSQL `whereRaw()` queries.
+- **Full-text language injection fix**: The language parameter in PostgreSQL full-text search is validated to only allow alphanumeric characters and underscores.
+- **Operator injection fix**: `Filter::generic()` now validates the operator via `FilterOperator::from()`, rejecting any value not defined in the enum.
+
+### Performance
+- Removed static `$cachedDatabaseDriver` property — the static cache caused test interference in multi-database scenarios and could return stale results in multi-tenant applications. The driver is now cached per-instance.
+- Removed unbounded `$validationCache` in `Filterable` trait — the MD5+`json_encode` overhead for caching trivial `in_array()` results was replaced with direct inline checks.
+- Removed redundant `setValueFromRequest()` call in `Filter::json()` factory — the constructor already calls it; JSON extraction happens lazily in `getValue()`.
+
+### Changed
+- Dependency updates: `phpunit` → 12.5.16, `phpstan` → 2.1.46, `pest` → 4.5.0, `rector` → 2.4.1, `symfony/*` → 7.4.8, `nesbot/carbon` → 3.11.4.
+
+### Upgrading from 2.0.x
+- No breaking changes for existing users on Laravel 11/12.
+- `Filter::generic()` now throws `InvalidArgumentException` for operators not present in `FilterOperator`. If you were passing raw SQL operators, migrate to the corresponding enum case.
+- `Filter::json()` with an empty or unsafe path now throws `InvalidArgumentException` instead of silently ignoring it.
+
 ## 1.1.4 - 2025-09-30
 
 ### Changed

--- a/tests/Unit/FilterEnhancedTest.php
+++ b/tests/Unit/FilterEnhancedTest.php
@@ -21,19 +21,15 @@ beforeEach(function (): void {
 it('validates date values correctly', function (): void {
     $filter = Filter::exact('created_at')->castDate();
 
-    // Valid date
     $filter->setValue('2023-01-01');
 
     expect($filter->getValue())->toBeInstanceOf(Carbon::class);
 
-    // Test the convertToCarbon method directly using reflection
     $reflector = new ReflectionClass($filter);
     $method = $reflector->getMethod('convertToCarbon');
 
-    // Valid date
     expect($method->invokeArgs($filter, ['2023-01-01']))->toBeInstanceOf(Carbon::class);
 
-    // Invalid date
     expect(fn (): mixed => $method->invokeArgs($filter, ['not-a-valid-date-format']))
         ->toThrow(InvalidArgumentException::class);
 });
@@ -42,21 +38,17 @@ it('uses isEmptyOrZero helper method correctly', function (): void {
     global $filters;
     $filters = ['data' => json_encode(['user' => ['name' => 'John']], JSON_THROW_ON_ERROR)];
 
-    // Test with valid json path
     $filter = Filter::json('data', 'user.name')->setDatabaseDriver('mysql');
     expect($filter->getAttribute())->toBe("data->>'$.user.name'");
 
-    // Test with invalid json paths — must throw
     expect(fn () => Filter::json('data', ''))->toThrow(InvalidArgumentException::class);
     expect(fn () => Filter::json('data', "user'; DROP TABLE users; --"))->toThrow(InvalidArgumentException::class);
 
-    // Without json path, use exact()
     $filter = Filter::exact('data')->setDatabaseDriver('mysql');
     expect($filter->getAttribute())->toBe('data');
 });
 
 it('handles database drivers correctly', function (): void {
-    // Test if the correct database driver methods are called
     $filter = Filter::json('data', 'user.name');
 
     $reflector = new ReflectionClass($filter);
@@ -64,19 +56,16 @@ it('handles database drivers correctly', function (): void {
     $sqliteMethod = $reflector->getMethod('isUsingSQLite');
     $pgsqlMethod = $reflector->getMethod('isUsingPostgreSQL');
 
-    // Test MySQL
     $filter->setDatabaseDriver('mysql');
     expect($mysqlMethod->invoke($filter))->toBeTrue();
     expect($sqliteMethod->invoke($filter))->toBeFalse();
     expect($pgsqlMethod->invoke($filter))->toBeFalse();
 
-    // Test SQLite
     $filter->setDatabaseDriver('sqlite');
     expect($mysqlMethod->invoke($filter))->toBeFalse();
     expect($sqliteMethod->invoke($filter))->toBeTrue();
     expect($pgsqlMethod->invoke($filter))->toBeFalse();
 
-    // Test PostgreSQL
     $filter->setDatabaseDriver('pgsql');
     expect($mysqlMethod->invoke($filter))->toBeFalse();
     expect($sqliteMethod->invoke($filter))->toBeFalse();
@@ -86,39 +75,29 @@ it('handles database drivers correctly', function (): void {
 it('validates array values correctly', function (): void {
     $filter = Filter::in('tags');
 
-    // Valid string array
     $filter->setValue(['tag1', 'tag2']);
-
     expect($filter->getValue())->toBe(['tag1', 'tag2']);
 
-    // Valid mixed string/int array
     $filter->setValue(['tag1', 2]);
     expect($filter->getValue())->toBe(['tag1', 2]);
 
-    // Invalid array
     expect(fn (): Filter => $filter->setValue(['tag1', []]))->toThrow(InvalidArgumentException::class);
 });
 
 it('uses match expressions for value transformation', function (): void {
-    // Test with direct values rather than request values
     $jsonStr = json_encode(['user' => ['status' => 'active']], JSON_THROW_ON_ERROR);
 
-    // Create a filter and manually set values to test the operators
     $filter = Filter::json('data', 'user.status', Filter::OPERATOR_EQUALS);
     $filter->setValue($jsonStr);
 
-    // Extract a value using reflection to directly test applyOperatorToValue
     $reflector = new ReflectionClass($filter);
     $method = $reflector->getMethod('applyOperatorToValue');
 
-    // Test EQUALS (default)
     expect($method->invokeArgs($filter, ['active']))->toBe('active');
 
-    // Test LIKE
     $filter = Filter::json('data', 'user.status', Filter::OPERATOR_LIKE);
     expect($method->invokeArgs($filter, ['active']))->toBe('%active%');
 
-    // Test IN with comma string
     $filter = Filter::json('data', 'user.status', Filter::OPERATOR_IN);
     expect($method->invokeArgs($filter, ['admin,user']))->toBe(['admin', 'user']);
 });
@@ -127,16 +106,13 @@ it('applies date modifiers correctly', function (): void {
     $now = Carbon::now();
     $filter = Filter::exact('created_at')->castDate()->setValue($now->format('Y-m-d'));
 
-    // Default (no modifiers)
     $date = $filter->getValue();
     expect($date->format('H:i:s'))->toBe('00:00:00');
 
-    // With endOfDay
     $filter = Filter::exact('created_at')->castDate()->endOfDay()->setValue($now->format('Y-m-d'));
     $date = $filter->getValue();
     expect($date->format('H:i:s'))->toBe('23:59:59');
 
-    // With startOfDay
     $filter = Filter::exact('created_at')->castDate()->startOfDay()->setValue($now->format('Y-m-d'));
     $date = $filter->getValue();
     expect($date->format('H:i:s'))->toBe('00:00:00');
@@ -145,17 +121,14 @@ it('applies date modifiers correctly', function (): void {
 it('prepares values correctly based on operator', function (): void {
     global $filters;
 
-    // BETWEEN with comma string
     $filters = ['date_range' => '2023-01-01,2023-12-31'];
     $filter = Filter::between('created_at', 'date_range');
     expect($filter->getValue())->toBe(['2023-01-01', '2023-12-31']);
 
-    // IN with comma string
     $filters = ['roles' => 'admin,user,guest'];
     $filter = Filter::in('role', 'roles');
     expect($filter->getValue())->toBe(['admin', 'user', 'guest']);
 
-    // LIKE with pattern
     $filters = ['search' => 'test'];
     $filter = Filter::like('name', 'search');
     expect($filter->getValue())->toBe('%test%');

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -45,7 +45,7 @@ it('can set and get a filter value', function (): void {
 
 it('throws exception for invalid array value in filter', function (): void {
     $filter = Filter::exact('tags');
-    $filter->setValue(['tag1', []]); // Use nested array which is definitely invalid
+    $filter->setValue(['tag1', []]);
 })->throws(InvalidArgumentException::class);
 
 it('can create a json filter com exact match', function (): void {

--- a/tests/Unit/FilterablePerformanceTest.php
+++ b/tests/Unit/FilterablePerformanceTest.php
@@ -35,20 +35,15 @@ class FilterablePerformanceTest extends TestCase
 
     public function test_relationship_load_optimization(): void
     {
-        // Create filters with same relationship to test deduplication
         $filter1 = $this->createRelationshipFilter('user', 'name', 'John', true);
         $filter2 = $this->createRelationshipFilter('user', 'email', 'john@example.com', true);
         $filter3 = $this->createRelationshipFilter('user', 'age', 30, true);
-
-        // In non-optimized code, we'd expect array_unique to be called
-        // In optimized code, we use array keys which avoids duplicates
 
         $this->query->shouldReceive('with')
             ->once()
             ->with(['user'])
             ->andReturnSelf();
 
-        // The trait groups filters by relationship, so 3 filters for 'user' = 1 whereHas call
         $this->query->shouldReceive('whereHas')
             ->once()
             ->andReturnSelf();
@@ -60,19 +55,15 @@ class FilterablePerformanceTest extends TestCase
 
     public function test_direct_filter_optimization(): void
     {
-        // Set up multiple direct filters
         $filter1 = $this->createDirectFilter('name', 'John');
         $filter2 = $this->createDirectFilter('email', 'john@example.com');
 
-        // Test that attribute resolution cache works
-        // We call scopeFilterable twice with 2 filters each = 4 where calls total
         $this->query->shouldReceive('where')
             ->times(4)
             ->andReturnSelf();
 
         $result = $this->model->scopeFilterable($this->query, [$filter1, $filter2]);
 
-        // Apply the same filters again - attributes should be cached
         $result = $this->model->scopeFilterable($this->query, [$filter1, $filter2]);
 
         $this->assertSame($this->query, $result);
@@ -80,7 +71,6 @@ class FilterablePerformanceTest extends TestCase
 
     public function test_simple_relationship_optimization(): void
     {
-        // This test checks if the optimized version uses a simple where for basic equality filters
         $filter = $this->createRelationshipFilter('user', 'name', 'John', false);
 
         $this->query->shouldReceive('whereHas')
@@ -105,7 +95,6 @@ class FilterablePerformanceTest extends TestCase
 
     public function test_conditional_logic_optimization(): void
     {
-        // Test the optimized conditional logic handler
         $filter = $this->createConditionalFilter('user', 'any', [
             ['name', '=', 'John'],
             ['email', '=', 'john@example.com'],
@@ -134,7 +123,6 @@ class FilterablePerformanceTest extends TestCase
         $relationshipFiltersCount = 0;
         $directFiltersCount = 0;
 
-        // Create 50 filters to test performance with larger datasets
         for ($i = 0; $i < 50; $i++) {
             if ($i % 3 === 0) {
                 $filters[] = $this->createRelationshipFilter('user', 'field'.$i, 'value'.$i, $i % 2 === 0);
@@ -145,17 +133,14 @@ class FilterablePerformanceTest extends TestCase
             }
         }
 
-        // Set up expectations for the filters
         $this->query->shouldReceive('where')
             ->times($directFiltersCount)
             ->andReturnSelf();
 
-        // All relationship filters use 'user', so 1 whereHas call
         $this->query->shouldReceive('whereHas')
             ->once()
             ->andReturnSelf();
 
-        // Some relationship filters have shouldWith = true
         $this->query->shouldReceive('with')
             ->zeroOrMoreTimes()
             ->andReturnSelf();
@@ -165,9 +150,8 @@ class FilterablePerformanceTest extends TestCase
         $this->model->scopeFilterable($this->query, $filters);
 
         $end = microtime(true);
-        $executionTime = ($end - $start) * 1000; // Convert to milliseconds
+        $executionTime = ($end - $start) * 1000;
 
-        // Just verify execution completes in a reasonable time
         $this->assertLessThan(500, $executionTime, 'Filtering should complete in less than 500ms');
     }
 


### PR DESCRIPTION
## Summary

- Remove redundant inline comments from test files — test descriptions via `it()` are self-documenting
- Add `v2.1.0` entry to `CHANGELOG.md` covering Laravel 13 support, security fixes, and performance improvements from #37

## Files changed
- `tests/Unit/FilterEnhancedTest.php`
- `tests/Unit/FilterablePerformanceTest.php`
- `tests/Unit/FilterTest.php`
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)