### PR TITLE
refactor: apply rector and pint automated fixes across codebase

### DIFF
--- a/src/Console/Commands/McpServeCommand.php
+++ b/src/Console/Commands/McpServeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DevactionLabs\FilterablePackage\Console\Commands;
 
 use DevactionLabs\FilterablePackage\MCP\FilterableMcpServer;

--- a/src/Enums/FilterOperator.php
+++ b/src/Enums/FilterOperator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DevactionLabs\FilterablePackage\Enums;
 
 /**

--- a/src/Enums/PaginationType.php
+++ b/src/Enums/PaginationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DevactionLabs\FilterablePackage\Enums;
 
 /**

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Facades\Request;
 use InvalidArgumentException;
 use JsonException;
+use ValueError;
 
 /**
  * Class Filter
@@ -336,11 +337,11 @@ class Filter
     {
         try {
             FilterOperator::from($operator);
-        } catch (\ValueError $e) {
+        } catch (ValueError $valueError) {
             throw new InvalidArgumentException(
                 sprintf('Invalid operator [%s]. Use a valid FilterOperator value.', $operator),
                 0,
-                $e
+                $valueError
             );
         }
 

--- a/src/FilterableServiceProvider.php
+++ b/src/FilterableServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DevactionLabs\FilterablePackage;
 
 use DevactionLabs\FilterablePackage\Console\Commands\McpServeCommand;

--- a/src/MCP/Contracts/Tool.php
+++ b/src/MCP/Contracts/Tool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DevactionLabs\FilterablePackage\MCP\Contracts;
 
 interface Tool

--- a/src/MCP/FilterableMcpServer.php
+++ b/src/MCP/FilterableMcpServer.php
@@ -7,18 +7,19 @@ use DevactionLabs\FilterablePackage\MCP\Tools\GenerateFiltersTool;
 use DevactionLabs\FilterablePackage\MCP\Tools\GetModelSchemaTool;
 use DevactionLabs\FilterablePackage\MCP\Tools\GetPackageDocsTool;
 use DevactionLabs\FilterablePackage\MCP\Tools\ListFilterableModelsTool;
+use stdClass;
 use Throwable;
 
 class FilterableMcpServer
 {
-    private const PROTOCOL_VERSION = '2024-11-05';
+    private const string PROTOCOL_VERSION = '2024-11-05';
 
-    private const SERVER_NAME = 'filterable-package';
+    private const string SERVER_NAME = 'filterable-package';
 
-    private const SERVER_VERSION = '1.0.0';
+    private const string SERVER_VERSION = '1.0.0';
 
     /** @var Tool[] */
-    private array $tools;
+    private readonly array $tools;
 
     public function __construct()
     {
@@ -68,10 +69,10 @@ class FilterableMcpServer
         return match ($method) {
             'initialize' => $this->handleInitialize($id),
             'notifications/initialized' => [],
-            'ping' => $this->ok($id, new \stdClass),
+            'ping' => $this->ok($id, new stdClass),
             'tools/list' => $this->handleToolsList($id),
             'tools/call' => $this->handleToolCall($id, isset($request['params']) && is_array($request['params']) ? $request['params'] : []),
-            default => $this->error($id, -32601, "Method not found: {$method}"),
+            default => $this->error($id, -32601, 'Method not found: '.$method),
         };
     }
 
@@ -123,7 +124,7 @@ class FilterableMcpServer
             }
         }
 
-        return $this->error($id, -32601, "Tool not found: {$name}");
+        return $this->error($id, -32601, 'Tool not found: '.$name);
     }
 
     /** @return array<string, mixed> */

--- a/src/MCP/Tools/GenerateFiltersTool.php
+++ b/src/MCP/Tools/GenerateFiltersTool.php
@@ -219,9 +219,11 @@ class GenerateFiltersTool implements Tool
             if ($method->class !== $class) {
                 continue;
             }
+
             if ($method->getNumberOfParameters() > 0) {
                 continue;
             }
+
             try {
                 $result = $method->invoke($instance);
                 if ($result instanceof Relation) {

--- a/src/MCP/Tools/GenerateFiltersTool.php
+++ b/src/MCP/Tools/GenerateFiltersTool.php
@@ -12,13 +12,13 @@ use Throwable;
 
 class GenerateFiltersTool implements Tool
 {
-    private const TEXT_TYPES = ['string', 'text', 'char', 'varchar', 'mediumtext', 'longtext', 'tinytext'];
+    private const array TEXT_TYPES = ['string', 'text', 'char', 'varchar', 'mediumtext', 'longtext', 'tinytext'];
 
-    private const DATE_TYPES = ['date', 'datetime', 'timestamp', 'timestamptz', 'datetimetz'];
+    private const array DATE_TYPES = ['date', 'datetime', 'timestamp', 'timestamptz', 'datetimetz'];
 
-    private const INTEGER_TYPES = ['integer', 'bigint', 'smallint', 'tinyint', 'int'];
+    private const array INTEGER_TYPES = ['integer', 'bigint', 'smallint', 'tinyint', 'int'];
 
-    private const DECIMAL_TYPES = ['decimal', 'float', 'double', 'numeric'];
+    private const array DECIMAL_TYPES = ['decimal', 'float', 'double', 'numeric'];
 
     public function name(): string
     {
@@ -50,7 +50,7 @@ class GenerateFiltersTool implements Tool
         $class = $this->resolveClass($modelArg);
 
         if ($class === null) {
-            return "Model '{$modelArg}' not found. Use list_filterable_models to see available models.";
+            return sprintf("Model '%s' not found. Use list_filterable_models to see available models.", $modelArg);
         }
 
         /** @var Model $instance */
@@ -81,17 +81,17 @@ class GenerateFiltersTool implements Tool
         }
 
         if ($filters === []) {
-            return "Could not generate filters for {$class}. Try calling get_model_schema('{$shortClass}') to inspect the model first.";
+            return sprintf("Could not generate filters for %s. Try calling get_model_schema('%s') to inspect the model first.", $class, $shortClass);
         }
 
-        $filterLines = array_map(fn (string $f) => "    {$f}", $filters);
+        $filterLines = array_map(fn (string $f): string => '    '.$f, $filters);
         $filterCode = implode("\n", $filterLines);
 
         $output = [];
-        $output[] = "// Filters for {$shortClass}";
+        $output[] = '// Filters for '.$shortClass;
         $output[] = '// Add to your controller: use DevactionLabs\\FilterablePackage\\Filter;';
         $output[] = '';
-        $output[] = "\${$this->varName($shortClass)} = {$shortClass}::filterable([";
+        $output[] = sprintf('$%s = %s::filterable([', $this->varName($shortClass), $shortClass);
         $output[] = $filterCode;
         $output[] = "])->customPaginate('paginate', 15);";
 
@@ -116,51 +116,51 @@ class GenerateFiltersTool implements Tool
                 $column === 'deleted_at' => null,
                 $column === 'remember_token' => null,
                 $column === 'password' => null,
-                str_ends_with($column, '_at') => "Filter::between('{$column}')->castDate(), // date range",
+                str_ends_with($column, '_at') => sprintf("Filter::between('%s')->castDate(), // date range", $column),
                 default => null,
             };
         }
 
         if (str_ends_with($column, '_id')) {
-            return "Filter::exact('{$column}'), // foreign key exact match";
+            return sprintf("Filter::exact('%s'), // foreign key exact match", $column);
         }
 
         if (in_array($column, ['status', 'type', 'state', 'role', 'gender', 'category'], true) || str_starts_with($column, 'is_') || str_starts_with($column, 'has_')) {
-            return "Filter::in('{$column}'), // accepts comma-separated values: ?filter[{$column}]=val1,val2";
+            return sprintf("Filter::in('%s'), // accepts comma-separated values: ?filter[%s]=val1,val2", $column, $column);
         }
 
         $resolvedType = $cast ?? $type;
 
         if (in_array($resolvedType, self::DATE_TYPES, true) || $resolvedType === 'datetime' || $resolvedType === 'date') {
-            return "Filter::between('{$column}')->castDate(), // date range: ?filter[{$column}]=2024-01-01,2024-12-31";
+            return sprintf("Filter::between('%s')->castDate(), // date range: ?filter[%s]=2024-01-01,2024-12-31", $column, $column);
         }
 
         if (in_array($resolvedType, self::TEXT_TYPES, true)) {
             if (str_contains($column, 'email')) {
-                return "Filter::ilike('{$column}'), // case-insensitive search";
+                return sprintf("Filter::ilike('%s'), // case-insensitive search", $column);
             }
 
             if (str_contains($column, 'name') || str_contains($column, 'title') || str_contains($column, 'description') || str_contains($column, 'slug') || str_contains($column, 'bio')) {
-                return "Filter::ilike('{$column}'), // case-insensitive text search";
+                return sprintf("Filter::ilike('%s'), // case-insensitive text search", $column);
             }
 
-            return "Filter::exact('{$column}'),";
+            return sprintf("Filter::exact('%s'),", $column);
         }
 
         if (in_array($resolvedType, self::INTEGER_TYPES, true)) {
-            return "Filter::between('{$column}'), // numeric range: ?filter[{$column}]=min,max";
+            return sprintf("Filter::between('%s'), // numeric range: ?filter[%s]=min,max", $column, $column);
         }
 
         if (in_array($resolvedType, self::DECIMAL_TYPES, true)) {
-            return "Filter::between('{$column}'), // decimal range: ?filter[{$column}]=min,max";
+            return sprintf("Filter::between('%s'), // decimal range: ?filter[%s]=min,max", $column, $column);
         }
 
         if ($resolvedType === 'boolean') {
-            return "Filter::exact('{$column}'), // boolean: ?filter[{$column}]=1 or 0";
+            return sprintf("Filter::exact('%s'), // boolean: ?filter[%s]=1 or 0", $column, $column);
         }
 
-        if ($resolvedType === 'json' || $resolvedType === 'array' || $resolvedType === 'object') {
-            return "// Filter::json('{$column}', 'nested.key'), // JSON field - specify path";
+        if (in_array($resolvedType, ['json', 'array', 'object'], true)) {
+            return sprintf("// Filter::json('%s', 'nested.key'), // JSON field - specify path", $column);
         }
 
         return null;
@@ -170,7 +170,7 @@ class GenerateFiltersTool implements Tool
     {
         $eagerLoad = in_array($type, ['HasOne', 'BelongsTo'], true) ? '->with()' : '';
 
-        return "Filter::relationship('{$relation}', 'id'){$eagerLoad}, // filter by {$relation} relationship";
+        return sprintf("Filter::relationship('%s', 'id')%s, // filter by %s relationship", $relation, $eagerLoad, $relation);
     }
 
     private function resolveClass(string $model): ?string
@@ -183,7 +183,7 @@ class GenerateFiltersTool implements Tool
             return $model;
         }
 
-        foreach (["App\\Models\\{$model}", "App\\{$model}"] as $candidate) {
+        foreach (['App\Models\\'.$model, 'App\\'.$model] as $candidate) {
             if (class_exists($candidate)) {
                 return $candidate;
             }
@@ -216,10 +216,12 @@ class GenerateFiltersTool implements Tool
         $reflector = new ReflectionClass($instance);
 
         foreach ($reflector->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->class !== $class || $method->getNumberOfParameters() > 0) {
+            if ($method->class !== $class) {
                 continue;
             }
-
+            if ($method->getNumberOfParameters() > 0) {
+                continue;
+            }
             try {
                 $result = $method->invoke($instance);
                 if ($result instanceof Relation) {
@@ -265,10 +267,10 @@ class GenerateFiltersTool implements Tool
             $resolvedType = $casts[$column] ?? $type;
 
             if (in_array($resolvedType, self::TEXT_TYPES, true)) {
-                $params[] = "filter[{$column}]=example";
+                $params[] = sprintf('filter[%s]=example', $column);
                 $count++;
             } elseif (in_array($resolvedType, self::DATE_TYPES, true) || str_ends_with($column, '_at')) {
-                $params[] = "filter[{$column}]=2024-01-01,2024-12-31";
+                $params[] = sprintf('filter[%s]=2024-01-01,2024-12-31', $column);
                 $count++;
             }
         }

--- a/src/MCP/Tools/GetModelSchemaTool.php
+++ b/src/MCP/Tools/GetModelSchemaTool.php
@@ -158,9 +158,11 @@ class GetModelSchemaTool implements Tool
             if ($method->class !== $class) {
                 continue;
             }
+
             if ($method->getNumberOfParameters() > 0) {
                 continue;
             }
+
             try {
                 $result = $method->invoke($instance);
                 if ($result instanceof Relation) {

--- a/src/MCP/Tools/GetModelSchemaTool.php
+++ b/src/MCP/Tools/GetModelSchemaTool.php
@@ -42,7 +42,7 @@ class GetModelSchemaTool implements Tool
         $class = $this->resolveClass($modelArg);
 
         if ($class === null) {
-            return "Model '{$modelArg}' not found. Use list_filterable_models to see available models.";
+            return sprintf("Model '%s' not found. Use list_filterable_models to see available models.", $modelArg);
         }
 
         /** @var Model $instance */
@@ -50,8 +50,8 @@ class GetModelSchemaTool implements Tool
         $table = $instance->getTable();
 
         $lines = [
-            "Model: {$class}",
-            "Table: {$table}",
+            'Model: '.$class,
+            'Table: '.$table,
             '',
         ];
 
@@ -62,10 +62,11 @@ class GetModelSchemaTool implements Tool
             $lines[] = 'Columns:';
             foreach ($columns as $column => $type) {
                 $cast = $casts[$column] ?? null;
-                $castSuffix = $cast ? " (cast: {$cast})" : '';
+                $castSuffix = $cast ? sprintf(' (cast: %s)', $cast) : '';
                 $nullable = $this->isNullable($table, $column) ? ' [nullable]' : '';
-                $lines[] = "  {$column}: {$type}{$castSuffix}{$nullable}";
+                $lines[] = sprintf('  %s: %s%s%s', $column, $type, $castSuffix, $nullable);
             }
+
             $lines[] = '';
         }
 
@@ -79,8 +80,9 @@ class GetModelSchemaTool implements Tool
         if ($relationships !== []) {
             $lines[] = 'Relationships:';
             foreach ($relationships as $name => $type) {
-                $lines[] = "  {$name}: {$type}";
+                $lines[] = sprintf('  %s: %s', $name, $type);
             }
+
             $lines[] = '';
         }
 
@@ -100,8 +102,8 @@ class GetModelSchemaTool implements Tool
         }
 
         $candidates = [
-            "App\\Models\\{$model}",
-            "App\\{$model}",
+            'App\Models\\'.$model,
+            'App\\'.$model,
         ];
 
         foreach ($candidates as $candidate) {
@@ -153,10 +155,12 @@ class GetModelSchemaTool implements Tool
         $reflector = new ReflectionClass($instance);
 
         foreach ($reflector->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->class !== $class || $method->getNumberOfParameters() > 0) {
+            if ($method->class !== $class) {
                 continue;
             }
-
+            if ($method->getNumberOfParameters() > 0) {
+                continue;
+            }
             try {
                 $result = $method->invoke($instance);
                 if ($result instanceof Relation) {

--- a/src/MCP/Tools/GetPackageDocsTool.php
+++ b/src/MCP/Tools/GetPackageDocsTool.php
@@ -3,6 +3,7 @@
 namespace DevactionLabs\FilterablePackage\MCP\Tools;
 
 use DevactionLabs\FilterablePackage\MCP\Contracts\Tool;
+use stdClass;
 
 class GetPackageDocsTool implements Tool
 {
@@ -20,7 +21,7 @@ class GetPackageDocsTool implements Tool
     {
         return [
             'type' => 'object',
-            'properties' => new \stdClass,
+            'properties' => new stdClass,
             'required' => [],
         ];
     }

--- a/src/MCP/Tools/ListFilterableModelsTool.php
+++ b/src/MCP/Tools/ListFilterableModelsTool.php
@@ -4,9 +4,13 @@ namespace DevactionLabs\FilterablePackage\MCP\Tools;
 
 use DevactionLabs\FilterablePackage\MCP\Contracts\Tool;
 use DevactionLabs\FilterablePackage\Traits\Filterable;
+use FilesystemIterator;
 use Illuminate\Support\Facades\App;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReflectionClass;
 use SplFileInfo;
+use stdClass;
 use Throwable;
 
 class ListFilterableModelsTool implements Tool
@@ -25,7 +29,7 @@ class ListFilterableModelsTool implements Tool
     {
         return [
             'type' => 'object',
-            'properties' => new \stdClass,
+            'properties' => new stdClass,
             'required' => [],
         ];
     }
@@ -41,13 +45,13 @@ class ListFilterableModelsTool implements Tool
         $found = $this->scanDirectory($modelsPath);
 
         if ($found === []) {
-            return "No models using the Filterable trait were found in {$modelsPath}.";
+            return sprintf('No models using the Filterable trait were found in %s.', $modelsPath);
         }
 
         $lines = ['Models using the Filterable trait:', ''];
         foreach ($found as $class => $file) {
-            $lines[] = "  - {$class}";
-            $lines[] = "    File: {$file}";
+            $lines[] = '  - '.$class;
+            $lines[] = '    File: '.$file;
         }
 
         $lines[] = '';
@@ -61,16 +65,18 @@ class ListFilterableModelsTool implements Tool
     private function scanDirectory(string $path): array
     {
         $found = [];
-        /** @var \RecursiveIteratorIterator<\RecursiveDirectoryIterator> $iterator */
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)
+        /** @var RecursiveIteratorIterator<RecursiveDirectoryIterator> $iterator */
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
         );
 
         foreach ($iterator as $file) {
-            if (! ($file instanceof SplFileInfo) || $file->getExtension() !== 'php') {
+            if (! ($file instanceof SplFileInfo)) {
                 continue;
             }
-
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
             $realPath = $file->getRealPath();
             if ($realPath === false) {
                 continue;
@@ -132,7 +138,7 @@ class ListFilterableModelsTool implements Tool
         $traits = array_keys($class->getTraits());
 
         if ($class->getParentClass() !== false) {
-            $traits = array_merge($traits, $this->getAllTraits($class->getParentClass()));
+            return array_merge($traits, $this->getAllTraits($class->getParentClass()));
         }
 
         return $traits;

--- a/src/MCP/Tools/ListFilterableModelsTool.php
+++ b/src/MCP/Tools/ListFilterableModelsTool.php
@@ -74,9 +74,11 @@ class ListFilterableModelsTool implements Tool
             if (! ($file instanceof SplFileInfo)) {
                 continue;
             }
+
             if ($file->getExtension() !== 'php') {
                 continue;
             }
+
             $realPath = $file->getRealPath();
             if ($realPath === false) {
                 continue;

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -452,7 +452,7 @@ trait Filterable
      */
     private function assertSafeColumnName(string $column): void
     {
-        if (! preg_match('/^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/', $column)) {
+        if (! preg_match('/^\w+(\.\w+)?$/', $column)) {
             throw new InvalidArgumentException(
                 sprintf('Invalid column name [%s] for full-text search. Only alphanumeric characters, underscores, and a single dot are allowed.', $column)
             );
@@ -468,7 +468,7 @@ trait Filterable
     {
         $lang = $language ?? Config::get('app.fulltext_language', 'simple');
 
-        if (! preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', (string) $lang)) {
+        if (! preg_match('/^[a-zA-Z_]\w*$/', (string) $lang)) {
             throw new InvalidArgumentException(
                 sprintf('Invalid full-text search language [%s]. Only alphanumeric characters and underscores are allowed.', $lang)
             );

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 test('example', function (): void {
     expect(true)->toBeTrue();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;

--- a/tests/Unit/FilterEnhancedTest.php
+++ b/tests/Unit/FilterEnhancedTest.php
@@ -41,8 +41,8 @@ it('uses isEmptyOrZero helper method correctly', function (): void {
     $filter = Filter::json('data', 'user.name')->setDatabaseDriver('mysql');
     expect($filter->getAttribute())->toBe("data->>'$.user.name'");
 
-    expect(fn () => Filter::json('data', ''))->toThrow(InvalidArgumentException::class);
-    expect(fn () => Filter::json('data', "user'; DROP TABLE users; --"))->toThrow(InvalidArgumentException::class);
+    expect(fn (): Filter => Filter::json('data', ''))->toThrow(InvalidArgumentException::class);
+    expect(fn (): Filter => Filter::json('data', "user'; DROP TABLE users; --"))->toThrow(InvalidArgumentException::class);
 
     $filter = Filter::exact('data')->setDatabaseDriver('mysql');
     expect($filter->getAttribute())->toBe('data');
@@ -76,6 +76,7 @@ it('validates array values correctly', function (): void {
     $filter = Filter::in('tags');
 
     $filter->setValue(['tag1', 'tag2']);
+
     expect($filter->getValue())->toBe(['tag1', 'tag2']);
 
     $filter->setValue(['tag1', 2]);

--- a/tests/Unit/MCP/FilterableMcpServerTest.php
+++ b/tests/Unit/MCP/FilterableMcpServerTest.php
@@ -87,3 +87,20 @@ it('responds to ping', function (): void {
     expect($response['id'])->toBe(6)
         ->and($response)->toHaveKey('result');
 });
+
+it('returns json-rpc error when tool execution throws an exception', function (): void {
+    $server = new FilterableMcpServer;
+
+    // get_model_schema with stdClass: resolveClass returns 'stdClass' (class_exists = true),
+    // then $instance->getTable() is called on a plain stdClass which throws an Error.
+    // This exercises the catch(Throwable) block in handleToolCall (lines 122-123).
+    $response = callDispatch($server, [
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'tools/call',
+        'params' => ['name' => 'get_model_schema', 'arguments' => ['model' => 'stdClass']],
+    ]);
+
+    expect($response)->toHaveKey('error')
+        ->and($response['error']['code'])->toBe(-32000);
+});

--- a/tests/Unit/MCP/GenerateFiltersToolTest.php
+++ b/tests/Unit/MCP/GenerateFiltersToolTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MCP;
+
+use DevactionLabs\FilterablePackage\MCP\Tools\GenerateFiltersTool;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use ReflectionClass;
+
+// Minimal Eloquent model for testing — no DB connection needed
+class GenerateTestModel extends Model
+{
+    protected $table = 'generate_test_models';
+
+    protected $casts = ['created_at' => 'datetime', 'is_active' => 'boolean'];
+}
+
+// Helpers to access private methods via reflection
+function callFilterForColumn(GenerateFiltersTool $tool, string $column, string $type, ?string $cast): ?string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('filterForColumn');
+
+    return $method->invoke($tool, $column, $type, $cast);
+}
+
+function callFilterForRelationship(GenerateFiltersTool $tool, string $relation, string $type): string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('filterForRelationship');
+
+    return $method->invoke($tool, $relation, $type);
+}
+
+function callVarName(GenerateFiltersTool $tool, string $class): string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('varName');
+
+    return $method->invoke($tool, $class);
+}
+
+function callRouteName(GenerateFiltersTool $tool, string $class): string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('routeName');
+
+    return $method->invoke($tool, $class);
+}
+
+function callBuildExampleParams(GenerateFiltersTool $tool, array $columns, array $casts): array
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('buildExampleParams');
+
+    return $method->invoke($tool, $columns, $casts);
+}
+
+function callResolveClass(GenerateFiltersTool $tool, string $model): ?string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('resolveClass');
+
+    return $method->invoke($tool, $model);
+}
+
+// Tool metadata
+it('has correct name', function (): void {
+    expect((new GenerateFiltersTool)->name())->toBe('generate_filters');
+});
+
+it('has non-empty description', function (): void {
+    expect((new GenerateFiltersTool)->description())->not->toBeEmpty();
+});
+
+it('has valid input schema with model property', function (): void {
+    $schema = (new GenerateFiltersTool)->inputSchema();
+
+    expect($schema['type'])->toBe('object')
+        ->and($schema['properties'])->toHaveKey('model')
+        ->and($schema['required'])->toContain('model');
+});
+
+// execute() error path (no DB needed)
+it('returns error message when model is not found', function (): void {
+    $result = (new GenerateFiltersTool)->execute(['model' => 'NonExistentModel99']);
+
+    expect($result)->toContain('NonExistentModel99')
+        ->toContain('not found');
+});
+
+it('returns error message when model arg is empty', function (): void {
+    $result = (new GenerateFiltersTool)->execute(['model' => '']);
+
+    expect($result)->toContain('not found');
+});
+
+// resolveClass
+it('resolveClass returns null for empty string', function (): void {
+    expect(callResolveClass(new GenerateFiltersTool, ''))->toBeNull();
+});
+
+it('resolveClass returns null for unknown class', function (): void {
+    expect(callResolveClass(new GenerateFiltersTool, 'App\\Models\\DoesNotExist'))->toBeNull();
+});
+
+it('resolveClass returns class when it exists', function (): void {
+    expect(callResolveClass(new GenerateFiltersTool, GenerateFiltersTool::class))
+        ->toBe(GenerateFiltersTool::class);
+});
+
+// filterForColumn — system columns
+it('filterForColumn returns null for id', function (): void {
+    expect(callFilterForColumn(new GenerateFiltersTool, 'id', 'integer', null))->toBeNull();
+});
+
+it('filterForColumn returns null for deleted_at', function (): void {
+    expect(callFilterForColumn(new GenerateFiltersTool, 'deleted_at', 'datetime', null))->toBeNull();
+});
+
+it('filterForColumn returns null for remember_token', function (): void {
+    expect(callFilterForColumn(new GenerateFiltersTool, 'remember_token', 'string', null))->toBeNull();
+});
+
+it('filterForColumn returns null for password', function (): void {
+    expect(callFilterForColumn(new GenerateFiltersTool, 'password', 'string', null))->toBeNull();
+});
+
+it('filterForColumn returns date range for created_at', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'created_at', 'datetime', null);
+
+    expect($result)->toContain('Filter::between')->toContain('castDate');
+});
+
+it('filterForColumn returns date range for updated_at', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'updated_at', 'datetime', null);
+
+    expect($result)->toContain('Filter::between')->toContain('castDate');
+});
+
+// filterForColumn — foreign keys
+it('filterForColumn returns exact for _id columns', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'user_id', 'integer', null);
+
+    expect($result)->toContain("Filter::exact('user_id')");
+});
+
+// filterForColumn — enum-like columns
+it('filterForColumn returns in() for status column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'status', 'string', null);
+
+    expect($result)->toContain("Filter::in('status')");
+});
+
+it('filterForColumn returns in() for type column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'type', 'string', null);
+
+    expect($result)->toContain("Filter::in('type')");
+});
+
+it('filterForColumn returns in() for is_ prefix columns', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'is_active', 'boolean', null);
+
+    expect($result)->toContain("Filter::in('is_active')");
+});
+
+it('filterForColumn returns in() for has_ prefix columns', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'has_photo', 'boolean', null);
+
+    expect($result)->toContain("Filter::in('has_photo')");
+});
+
+// filterForColumn — text types
+it('filterForColumn returns ilike for email column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'email', 'string', null);
+
+    expect($result)->toContain("Filter::ilike('email')");
+});
+
+it('filterForColumn returns ilike for name column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'name', 'string', null);
+
+    expect($result)->toContain("Filter::ilike('name')");
+});
+
+it('filterForColumn returns ilike for title column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'title', 'string', null);
+
+    expect($result)->toContain("Filter::ilike('title')");
+});
+
+it('filterForColumn returns ilike for description column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'description', 'text', null);
+
+    expect($result)->toContain("Filter::ilike('description')");
+});
+
+it('filterForColumn returns ilike for slug column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'slug', 'string', null);
+
+    expect($result)->toContain("Filter::ilike('slug')");
+});
+
+it('filterForColumn returns ilike for bio column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'bio', 'text', null);
+
+    expect($result)->toContain("Filter::ilike('bio')");
+});
+
+it('filterForColumn returns exact for generic text column', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'token', 'string', null);
+
+    expect($result)->toContain("Filter::exact('token')");
+});
+
+// filterForColumn — date/datetime types
+it('filterForColumn returns between with castDate for date type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'birth_date', 'date', null);
+
+    expect($result)->toContain('Filter::between')->toContain('castDate');
+});
+
+it('filterForColumn returns between with castDate for timestamp type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'published_at', 'timestamp', null);
+
+    expect($result)->toContain('Filter::between')->toContain('castDate');
+});
+
+// filterForColumn — numeric types
+it('filterForColumn returns between for integer type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'age', 'integer', null);
+
+    expect($result)->toContain("Filter::between('age')");
+});
+
+it('filterForColumn returns between for bigint type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'views', 'bigint', null);
+
+    expect($result)->toContain("Filter::between('views')");
+});
+
+it('filterForColumn returns between for decimal type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'price', 'decimal', null);
+
+    expect($result)->toContain("Filter::between('price')");
+});
+
+it('filterForColumn returns between for float type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'rating', 'float', null);
+
+    expect($result)->toContain("Filter::between('rating')");
+});
+
+// filterForColumn — boolean type
+it('filterForColumn returns exact for boolean type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'active', 'boolean', null);
+
+    expect($result)->toContain("Filter::exact('active')");
+});
+
+// filterForColumn — json type
+it('filterForColumn returns json comment for json type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'settings', 'json', null);
+
+    expect($result)->toContain("Filter::json('settings'");
+});
+
+it('filterForColumn returns json comment for array cast', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'meta', 'json', 'array');
+
+    expect($result)->toContain("Filter::json('meta'");
+});
+
+// filterForColumn — cast overrides type
+it('filterForColumn uses cast over raw type for date', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'scheduled_for', 'string', 'datetime');
+
+    expect($result)->toContain('castDate');
+});
+
+// filterForColumn — unknown type returns null
+it('filterForColumn returns null for unknown type', function (): void {
+    $result = callFilterForColumn(new GenerateFiltersTool, 'unknown_col', 'geometry', null);
+
+    expect($result)->toBeNull();
+});
+
+// filterForRelationship
+it('filterForRelationship generates relationship filter without eager load for HasMany', function (): void {
+    $result = callFilterForRelationship(new GenerateFiltersTool, 'posts', 'HasMany');
+
+    expect($result)->toContain("Filter::relationship('posts', 'id')")
+        ->not->toContain('->with()');
+});
+
+it('filterForRelationship adds with() for BelongsTo', function (): void {
+    $result = callFilterForRelationship(new GenerateFiltersTool, 'category', 'BelongsTo');
+
+    expect($result)->toContain("Filter::relationship('category', 'id')")->toContain('->with()');
+});
+
+it('filterForRelationship adds with() for HasOne', function (): void {
+    $result = callFilterForRelationship(new GenerateFiltersTool, 'profile', 'HasOne');
+
+    expect($result)->toContain('->with()');
+});
+
+// varName
+it('varName lowercases first letter and appends s', function (): void {
+    expect(callVarName(new GenerateFiltersTool, 'User'))->toBe('users');
+});
+
+it('varName handles multi-word class names', function (): void {
+    expect(callVarName(new GenerateFiltersTool, 'BlogPost'))->toBe('blogPosts');
+});
+
+// routeName
+it('routeName converts CamelCase to kebab-case with plural', function (): void {
+    expect(callRouteName(new GenerateFiltersTool, 'User'))->toBe('users');
+});
+
+it('routeName handles multi-word class names', function (): void {
+    expect(callRouteName(new GenerateFiltersTool, 'BlogPost'))->toBe('blog-posts');
+});
+
+// buildExampleParams
+it('buildExampleParams returns text params for string columns', function (): void {
+    $params = callBuildExampleParams(new GenerateFiltersTool, ['name' => 'string'], []);
+
+    expect($params)->toContain('filter[name]=example');
+});
+
+it('buildExampleParams returns date params for date columns', function (): void {
+    $params = callBuildExampleParams(new GenerateFiltersTool, ['created_at' => 'datetime'], []);
+
+    expect($params)->toContain('filter[created_at]=2024-01-01,2024-12-31');
+});
+
+it('buildExampleParams limits to 3 params', function (): void {
+    $columns = [
+        'name' => 'string',
+        'email' => 'string',
+        'title' => 'string',
+        'bio' => 'string',
+    ];
+
+    expect(callBuildExampleParams(new GenerateFiltersTool, $columns, []))->toHaveCount(3);
+});
+
+it('buildExampleParams skips password and id columns', function (): void {
+    $params = callBuildExampleParams(new GenerateFiltersTool, ['id' => 'integer', 'password' => 'string', 'name' => 'string'], []);
+
+    $joined = implode('&', $params);
+
+    expect($joined)->not->toContain('filter[id]')
+        ->not->toContain('filter[password]')
+        ->toContain('filter[name]');
+});
+
+// execute() with mocked Schema — covers the generate loop + output building
+it('execute() generates filter code for a model with mocked columns', function (): void {
+    Schema::clearResolvedInstances();
+
+    Schema::shouldReceive('getColumnListing')
+        ->with('generate_test_models')
+        ->andReturn(['id', 'name', 'status', 'price', 'created_at']);
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'id')->andReturn('integer');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'name')->andReturn('string');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'status')->andReturn('string');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'price')->andReturn('decimal');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'created_at')->andReturn('datetime');
+
+    $result = (new GenerateFiltersTool)->execute(['model' => GenerateTestModel::class]);
+
+    expect($result)
+        ->toContain('Filter::ilike')
+        ->toContain('Filter::in')
+        ->toContain('Filter::between')
+        ->toContain('customPaginate')
+        ->toContain('GenerateTestModel::filterable');
+});
+
+it('execute() includes skipped columns comment for uncategorised types', function (): void {
+    Schema::clearResolvedInstances();
+
+    // 'name' generates a filter; 'geo_point' is unknown → ends up in skipped list
+    Schema::shouldReceive('getColumnListing')
+        ->with('generate_test_models')
+        ->andReturn(['name', 'geo_point']);
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'name')->andReturn('string');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('generate_test_models', 'geo_point')->andReturn('geometry');
+
+    $result = (new GenerateFiltersTool)->execute(['model' => GenerateTestModel::class]);
+
+    expect($result)->toContain('geo_point')
+        ->toContain('Columns without auto-generated filters');
+});

--- a/tests/Unit/MCP/GetModelSchemaToolTest.php
+++ b/tests/Unit/MCP/GetModelSchemaToolTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MCP;
+
+use DevactionLabs\FilterablePackage\MCP\Tools\GetModelSchemaTool;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use ReflectionClass;
+
+// Minimal Eloquent model for testing — no DB connection needed for getTable()/getCasts()
+class SchemaTestModel extends Model
+{
+    protected $table = 'schema_test_models';
+
+    protected $fillable = ['name', 'email'];
+
+    protected $casts = ['created_at' => 'datetime'];
+}
+
+function callResolveModelClass(GetModelSchemaTool $tool, string $model): ?string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('resolveClass');
+
+    return $method->invoke($tool, $model);
+}
+
+it('has correct name', function (): void {
+    expect((new GetModelSchemaTool)->name())->toBe('get_model_schema');
+});
+
+it('has non-empty description', function (): void {
+    expect((new GetModelSchemaTool)->description())->not->toBeEmpty();
+});
+
+it('has valid input schema with model property', function (): void {
+    $schema = (new GetModelSchemaTool)->inputSchema();
+
+    expect($schema['type'])->toBe('object')
+        ->and($schema['properties'])->toHaveKey('model')
+        ->and($schema['required'])->toContain('model');
+});
+
+it('returns error message when model is not found', function (): void {
+    $result = (new GetModelSchemaTool)->execute(['model' => 'NonExistentModel99']);
+
+    expect($result)->toContain('NonExistentModel99')
+        ->toContain('not found');
+});
+
+it('returns error message when model arg is missing', function (): void {
+    $result = (new GetModelSchemaTool)->execute([]);
+
+    expect($result)->toContain('not found');
+});
+
+it('resolveClass returns null for empty string', function (): void {
+    expect(callResolveModelClass(new GetModelSchemaTool, ''))->toBeNull();
+});
+
+it('resolveClass returns null for unknown class', function (): void {
+    expect(callResolveModelClass(new GetModelSchemaTool, 'App\\Models\\Ghost'))->toBeNull();
+});
+
+it('resolveClass returns fully qualified class when it already exists', function (): void {
+    expect(callResolveModelClass(new GetModelSchemaTool, GetModelSchemaTool::class))
+        ->toBe(GetModelSchemaTool::class);
+});
+
+// execute() with mocked Schema — covers lines 49-91, 119-133, 136-148, 151-175
+it('execute() returns schema info for a model with mocked columns', function (): void {
+    Schema::clearResolvedInstances();
+
+    Schema::shouldReceive('getColumnListing')
+        ->with('schema_test_models')
+        ->andReturn(['id', 'name', 'email', 'created_at']);
+
+    Schema::shouldReceive('getColumnType')
+        ->with('schema_test_models', 'id')->andReturn('integer');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('schema_test_models', 'name')->andReturn('string');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('schema_test_models', 'email')->andReturn('string');
+
+    Schema::shouldReceive('getColumnType')
+        ->with('schema_test_models', 'created_at')->andReturn('datetime');
+
+    // isNullable uses Schema::getColumns
+    Schema::shouldReceive('getColumns')
+        ->with('schema_test_models')
+        ->andReturn([
+            ['name' => 'id', 'nullable' => false],
+            ['name' => 'name', 'nullable' => true],
+            ['name' => 'email', 'nullable' => false],
+            ['name' => 'created_at', 'nullable' => true],
+        ]);
+
+    $result = (new GetModelSchemaTool)->execute(['model' => SchemaTestModel::class]);
+
+    expect($result)
+        ->toContain('Table: schema_test_models')
+        ->toContain('Columns:')
+        ->toContain('name: string')
+        ->toContain('[nullable]')
+        ->toContain('Fillable: name, email')
+        ->toContain('generate_filters');
+});
+
+it('execute() returns schema without fillable section when model has no fillable', function (): void {
+    Schema::clearResolvedInstances();
+
+    Schema::shouldReceive('getColumnListing')
+        ->with('schema_test_models')
+        ->andReturn([]);
+
+    Schema::shouldReceive('getColumns')
+        ->with('schema_test_models')
+        ->andReturn([]);
+
+    $result = (new GetModelSchemaTool)->execute(['model' => SchemaTestModel::class]);
+
+    expect($result)->toContain('generate_filters');
+});

--- a/tests/Unit/MCP/ListFilterableModelsToolTest.php
+++ b/tests/Unit/MCP/ListFilterableModelsToolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MCP;
+
+use DevactionLabs\FilterablePackage\MCP\Tools\ListFilterableModelsTool;
+use DevactionLabs\FilterablePackage\Traits\Filterable;
+use Illuminate\Support\Facades\App;
+use ReflectionClass;
+
+function callResolveClassName(ListFilterableModelsTool $tool, string $filePath): ?string
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('resolveClassName');
+
+    return $method->invoke($tool, $filePath);
+}
+
+function callUsesFilterableTrait(ListFilterableModelsTool $tool, string $class): bool
+{
+    $ref = new ReflectionClass($tool);
+    $method = $ref->getMethod('usesFilterableTrait');
+
+    return $method->invoke($tool, $class);
+}
+
+it('has correct name', function (): void {
+    expect((new ListFilterableModelsTool)->name())->toBe('list_filterable_models');
+});
+
+it('has non-empty description', function (): void {
+    expect((new ListFilterableModelsTool)->description())->not->toBeEmpty();
+});
+
+it('has valid input schema with no required properties', function (): void {
+    $schema = (new ListFilterableModelsTool)->inputSchema();
+
+    expect($schema['type'])->toBe('object')
+        ->and($schema['required'])->toBe([]);
+});
+
+it('returns no-directory message when app/Models does not exist', function (): void {
+    App::clearResolvedInstances();
+    App::shouldReceive('basePath')->with('app/Models')->andReturn('/nonexistent/path/app/models');
+
+    $result = (new ListFilterableModelsTool)->execute([]);
+
+    expect($result)->toContain('No app/Models directory found');
+});
+
+it('returns no-models message when directory has no filterable classes', function (): void {
+    // Create a temp directory with a PHP file that defines a class
+    $dir = sys_get_temp_dir().'/filterable_test_'.uniqid();
+    mkdir($dir);
+    file_put_contents($dir.'/Ghost.php', "<?php\nnamespace App\\Models;\nclass Ghost {}\n");
+
+    App::clearResolvedInstances();
+    App::shouldReceive('basePath')->with('app/Models')->andReturn($dir);
+    // basePath() without args is called when building the relative path display
+    App::shouldReceive('basePath')->withNoArgs()->andReturn($dir);
+
+    $result = (new ListFilterableModelsTool)->execute([]);
+
+    // Cleanup
+    unlink($dir.'/Ghost.php');
+    rmdir($dir);
+
+    expect($result)->toContain('No models using the Filterable trait were found');
+});
+
+// resolveClassName — pure PHP, no facade needed
+it('resolveClassName returns null when file has no namespace', function (): void {
+    $file = tempnam(sys_get_temp_dir(), 'test_');
+    file_put_contents($file, "<?php\nclass Foo {}\n");
+
+    expect(callResolveClassName(new ListFilterableModelsTool, $file))->toBeNull();
+
+    unlink($file);
+});
+
+it('resolveClassName returns null when file has no class declaration', function (): void {
+    $file = tempnam(sys_get_temp_dir(), 'test_');
+    file_put_contents($file, "<?php\nnamespace App\\Models;\n");
+
+    expect(callResolveClassName(new ListFilterableModelsTool, $file))->toBeNull();
+
+    unlink($file);
+});
+
+it('resolveClassName returns FQCN when namespace and class are present', function (): void {
+    $file = tempnam(sys_get_temp_dir(), 'test_');
+    file_put_contents($file, "<?php\nnamespace App\\Models;\nclass User {}\n");
+
+    expect(callResolveClassName(new ListFilterableModelsTool, $file))->toBe('App\\Models\\User');
+
+    unlink($file);
+});
+
+// usesFilterableTrait — pure PHP reflection
+it('usesFilterableTrait returns false for non-existent class', function (): void {
+    expect(callUsesFilterableTrait(new ListFilterableModelsTool, 'NonExistentClass999'))->toBeFalse();
+});
+
+it('usesFilterableTrait returns false for class without filterable trait', function (): void {
+    expect(callUsesFilterableTrait(new ListFilterableModelsTool, ListFilterableModelsTool::class))->toBeFalse();
+});
+
+it('usesFilterableTrait returns true for class using Filterable trait', function (): void {
+    $class = new class
+    {
+        use Filterable;
+    };
+
+    expect(callUsesFilterableTrait(new ListFilterableModelsTool, $class::class))->toBeTrue();
+});

--- a/tests/Unit/MCP/McpServeCommandTest.php
+++ b/tests/Unit/MCP/McpServeCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MCP;
+
+use DevactionLabs\FilterablePackage\Console\Commands\McpServeCommand;
+
+it('has correct artisan signature', function (): void {
+    $command = new McpServeCommand;
+
+    expect($command->getName())->toBe('filterable:mcp');
+});
+
+it('has a non-empty description', function (): void {
+    $command = new McpServeCommand;
+
+    expect($command->getDescription())->not->toBeEmpty();
+});


### PR DESCRIPTION
- Add declare(strict_types=1) to all source and test files
- Type class constants (string/array) in FilterableMcpServer and GenerateFiltersTool
- Make $tools property readonly in FilterableMcpServer
- Replace string interpolation with sprintf/concatenation per pint rules
- Fix import ordering and unary/not operator spacing
- Rename catch variable to match exception type in Filter::generic()